### PR TITLE
Update find_between.m

### DIFF
--- a/utils/find_between.m
+++ b/utils/find_between.m
@@ -29,8 +29,8 @@ while abs(midval - val) > thres
     mid = (left + right) / 2;
     midval = func(mid);
     cnt = cnt + 1;
-    if cnt > 10000
-        keyboard;
-    end
+    % if cnt > 10000
+    %    keyboard;
+    % end
 end
 res = mid;


### PR DESCRIPTION
Remove the call to 'keyboard' to prevent Matlab from entering debug mode.