### PR TITLE
Remove debug keyboard call in utils/find_between.m

### DIFF
--- a/utils/find_between.m
+++ b/utils/find_between.m
@@ -29,8 +29,8 @@ while abs(midval - val) > thres
     mid = (left + right) / 2;
     midval = func(mid);
     cnt = cnt + 1;
-    if cnt > 10000
-        keyboard;
-    end
+    % if cnt > 10000
+    %    keyboard;
+    % end
 end
 res = mid;


### PR DESCRIPTION
Removes an accidental 'keyboard' call in utils/find_between.m that could drop MATLAB into debug mode when the bisection loop iterated many times. The call is commented out to avoid interrupting automated runs or tests.